### PR TITLE
feat: is active

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,7 @@
 # -*- mode: Python -*-
 
 k8s_yaml(helm('./helm'))
+load('ext://secret', 'secret_create_generic', 'secret_from_dict')
 
 IS_CI = config.tilt_subcommand == 'ci'
 GRAFANA_PORT_FORWARD=3001
@@ -25,6 +26,9 @@ k8s_resource(
 
 go_compile('rpc-compile', './rpc', ['./rpc'])
 go_image('rpc', './rpc')
+k8s_yaml(secret_from_dict("rpc-auth", inputs={
+  "DB_MYSQL_DSN": "amalgam-user:amalgam-password@tcp(mysql:3306)/amalgam-db?charset=utf8mb4&parseTime=True&loc=Local"
+}))
 k8s_resource(
   "rpc",
   port_forwards=[
@@ -77,14 +81,15 @@ cmd_button('run-start',
 
 go_compile('feed-start-compile', './data-pipeline/temporal/feed/start', ['./data-pipeline/temporal'])
 go_image('feed-start', './data-pipeline/temporal/feed/start')
-k8s_resource("feed-start", resource_deps=["temporal"], labels=["data-pipeline"], auto_init=False)
+k8s_resource("feed-start", resource_deps=["temporal","rpc"], labels=["data-pipeline"], auto_init=False, trigger_mode=TRIGGER_MODE_MANUAL)
 
 go_compile('feed-worker-compile', './data-pipeline/temporal/feed/worker', ['./data-pipeline/temporal'])
 go_image('feed-worker', './data-pipeline/temporal/feed/worker')
-k8s_resource("feed-worker", resource_deps=["temporal"], labels=["data-pipeline"],
+k8s_resource("feed-worker", resource_deps=["temporal","rpc"], labels=["data-pipeline"],
   port_forwards=[
     port_forward(9096, 9090, "metrics")
   ],
+  trigger_mode=TRIGGER_MODE_MANUAL,
   auto_init=False,
 )
 
@@ -92,9 +97,8 @@ k8s_resource("feed-worker", resource_deps=["temporal"], labels=["data-pipeline"]
 docker_build("k6-image", "k6")
 k8s_resource("k6", trigger_mode=TRIGGER_MODE_MANUAL, resource_deps=["api"], labels=["test"])
 
-load('./containers/tilt/extensions/mysql/Tiltfile', 'deploy_mysql', 'deploy_mysql_migrate')
-deploy_mysql()
-deploy_mysql_migrate()
+load('./containers/tilt/extensions/mysql/Tiltfile', 'deploy_mysql')
+deploy_mysql(root_pw="password", user_pw="amalgam-password", migration_pw="password")
 
 load('./containers/tilt/extensions/temporal/Tiltfile', 'deploy_temporal')
 deploy_temporal(auto_init=(not IS_CI))

--- a/containers/tilt/extensions/mysql/Tiltfile
+++ b/containers/tilt/extensions/mysql/Tiltfile
@@ -1,8 +1,16 @@
 # TODO: make configurable
+load('ext://secret', 'secret_create_generic', 'secret_from_dict')
 
-def deploy_mysql():
+def deploy_mysql(root_pw="password", user_pw="amalgam-password", migration_pw="password"):
+    k8s_yaml(secret_from_dict("mysql-auth", inputs={
+        "MYSQL_ROOT_PASSWORD": root_pw,
+    }))
+    k8s_yaml(secret_from_dict("feed-mysql-auth", inputs={
+        "AMALGAM_MIGRATION_PASSWORD": migration_pw,
+        "AMALGAM_USER_PASSWORD": user_pw,
+    }))
+
     k8s_resource("mysql", port_forwards=["3306:3306"], labels=["services"])
 
-def deploy_mysql_migrate():
     docker_build("mysql-migrate-image", "mysql/migrations", dockerfile="mysql/migrate.Dockerfile")
     k8s_resource("mysql-migrate", resource_deps=["mysql"], labels=["services"])

--- a/helm/templates/mysql.yaml
+++ b/helm/templates/mysql.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mysql
 spec:
   ports:
-    - name: "3306"
+    - name: mysql-server
       port: 3306
       targetPort: 3306
   selector:
@@ -35,21 +35,16 @@ spec:
       containers:
         - name: mysql
           image: mysql:8
+          volumeMounts:
+            - name: mysql-setup
+              mountPath: /docker-entrypoint-initdb.d/setup.sql
+              subPath: setup.sql
           env:
             - name: MYSQL_ROOT_PASSWORD
-              value: password
-            # TODO: might be possible to use this instead of setup.sql entrypoint. i prefer entrypoint as it lets me configure different users for app vs migration
-            # - name: MYSQL_DATABASE
-            #   value: amalgam-db
-            # - name: MYSQL_USER
-            #   value: amalgam-migration
-            # - name: MYSQL_PASSWORD
-            #   value: password
-            # - name: MYSQL_ALLOW_EMPTY_PASSWORD
-            #   value: "false"
-          volumeMounts:
-            - name: mysql-setup-sql
-              mountPath: /docker-entrypoint-initdb.d
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-auth
+                  key: MYSQL_ROOT_PASSWORD
           ports:
             - containerPort: 3306
           resources: {}
@@ -59,10 +54,38 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
+      initContainers:
+        - name: init-mysql-setup
+          image: alpine:latest
+          command:
+            [
+              "sh",
+              "-c",
+              "apk add --no-cache gettext && envsubst < /template/setup.sql > /config/setup.sql",
+            ]
+          env:
+            - name: AMALGAM_MIGRATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: feed-mysql-auth
+                  key: AMALGAM_MIGRATION_PASSWORD
+            - name: AMALGAM_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: feed-mysql-auth
+                  key: AMALGAM_USER_PASSWORD
+          volumeMounts:
+            - name: template
+              mountPath: /template
+            - name: mysql-setup
+              mountPath: /config
       volumes:
-        - name: mysql-setup-sql
+        - name: template
           configMap:
             name: mysql-setup-sql
+        - name: mysql-setup
+          emptyDir: {}
+
       restartPolicy: Always
 status: {}
 --- # configmap.yaml
@@ -71,22 +94,15 @@ kind: ConfigMap
 metadata:
   name: mysql-setup-sql
 data:
+  # TODO: secrets manager
   setup.sql: |
     SET GLOBAL max_allowed_packet=32505856;
     CREATE DATABASE `amalgam-db`;
 
-    CREATE USER 'amalgam-migration'@'%'
-      IDENTIFIED WITH caching_sha2_password BY 'amalgam-password';
-    GRANT
-      ALL PRIVILEGES
-      ON `amalgam-db`.*
-      TO 'amalgam-migration'@'%';
+    CREATE USER 'amalgam-migration'@'%' IDENTIFIED WITH caching_sha2_password BY '${AMALGAM_MIGRATION_PASSWORD}';
+    GRANT ALL PRIVILEGES ON `amalgam-db`.* TO 'amalgam-migration'@'%';
 
-    CREATE USER 'amalgam-user'@'%'
-      IDENTIFIED WITH caching_sha2_password BY 'amalgam-password';
-    GRANT
-      SELECT, INSERT, UPDATE, DELETE
-      ON `amalgam-db`.*
-      TO 'amalgam-user'@'%';
+    CREATE USER 'amalgam-user'@'%' IDENTIFIED WITH caching_sha2_password BY '${AMALGAM_USER_PASSWORD}';
+    GRANT SELECT, INSERT, UPDATE, DELETE ON `amalgam-db`.* TO 'amalgam-user'@'%';
 
     FLUSH PRIVILEGES;

--- a/helm/templates/rpc.yaml
+++ b/helm/templates/rpc.yaml
@@ -49,8 +49,8 @@ spec:
               value: "http://lgtm:4318"
             - name: DB_ADAPTER
               value: "mysql"
-            - name: DB_MYSQL_DSN # Note: DB_MYSQL_DSN must be a secret in production env
-              value: "amalgam-user:amalgam-password@tcp(mysql:3306)/amalgam-db?charset=utf8mb4&parseTime=True&loc=Local"
-            # root can be used to allow gorm migrations (but shouldn't be used during operation):
-            # - name: DB_MYSQL_DSN # Note: DB_MYSQL_DSN must be a secret in production env
-            #   value: "root:password@tcp(mysql:3306)/amalgam-db?charset=utf8mb4&parseTime=True&loc=Local"
+            - name: DB_MYSQL_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: rpc-auth
+                  key: DB_MYSQL_DSN

--- a/internal/db/models/models.go
+++ b/internal/db/models/models.go
@@ -9,8 +9,9 @@ import (
 
 type Feed struct {
 	Base
-	Url  string `json:"url" gorm:"uniqueIndex" binding:"required,url" example:"https://example.com/"`
-	Name string `json:"name" example:"Example"`
+	Url      string `json:"url" gorm:"uniqueIndex" binding:"required,url" example:"https://example.com/"`
+	Name     string `json:"name" example:"Example"`
+	IsActive bool   `json:"isActive" example:"true"`
 }
 
 type Article struct {

--- a/internal/service/gorm.go
+++ b/internal/service/gorm.go
@@ -30,8 +30,9 @@ func (s *GormService) query(ctx context.Context) *gorm.DB {
 func (s *GormService) Feeds(ctx context.Context) ([]svc_model.Feed, error) {
 	var feeds []svc_model.Feed
 	result := s.query(ctx).
-		Find(&feeds).
-		Limit(100) // TODO: pagination
+		Where("is_active=?", true).
+		Limit(100). // TODO: pagination
+		Find(&feeds)
 
 	if result.Error != nil {
 		return nil, errors.New("failed to fetch feeds")
@@ -91,6 +92,9 @@ func (s *GormService) CreateFeed(ctx context.Context, data *svc_model.Feed) (Cre
 
 	dbFeed := &db_model.Feed{}
 	copygen.ServiceToDbFeed(dbFeed, &feed)
+
+	dbFeed.IsActive = true
+
 	err = s.query(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := feedUrlExists(tx, feed.Url); err != nil {
 			return err
@@ -140,8 +144,8 @@ func (s *GormService) GetFeed(ctx context.Context, id string) (*svc_model.Feed, 
 func (s *GormService) GetArticlesByFeed(ctx context.Context, feedId string) ([]svc_model.Article, error) {
 	var articles []svc_model.Article
 	result := s.query(ctx).
-		Find(&articles, "feed_id=?", feedId).
-		Limit(100) // TODO: pagination (cursor)
+		Limit(100). // TODO: pagination (cursor)
+		Find(&articles, "feed_id=?", feedId)
 
 	if result.Error != nil {
 		return nil, result.Error

--- a/internal/service/models/models.go
+++ b/internal/service/models/models.go
@@ -1,9 +1,10 @@
 package models
 
 type Feed struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Url  string `json:"url" validate:"required,url"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Url      string `json:"url" validate:"required,url"`
+	IsActive bool   `json:"isActive"`
 }
 
 type Article struct {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ericbutera/amalgam/internal/db"
+	db_model "github.com/ericbutera/amalgam/internal/db/models"
 	service "github.com/ericbutera/amalgam/internal/service"
 	models "github.com/ericbutera/amalgam/internal/service/models"
 	"github.com/ericbutera/amalgam/internal/test/fixtures"
@@ -42,7 +43,7 @@ func mustNewTestDb(t *testing.T) *gorm.DB {
 }
 
 type AllowedModels interface {
-	*models.Feed | *models.Article
+	*models.Feed | *models.Article | *db_model.Feed | *db_model.Article
 }
 
 func Create[T AllowedModels](db *gorm.DB, records ...*T) error {
@@ -70,6 +71,18 @@ func (s *ServiceSuite) TestFeeds() {
 	assert.Len(t, feeds, 1)
 	assert.Equal(t, feed.Url, feeds[0].Url)
 	assert.Equal(t, feed.Name, feeds[0].Name)
+}
+
+func (s *ServiceSuite) TestFeeds_IsActive() {
+	t := s.T()
+
+	feed := fixtures.NewFeed(fixtures.WithFeedIsActive(false))
+	mustCreate(t, s.db, &feed)
+
+	feeds, err := s.svc.Feeds(context.Background())
+	require.NoError(t, err)
+
+	assert.Len(t, feeds, 0)
 }
 
 func (s *ServiceSuite) TestCreateFeed() {

--- a/internal/test/fixtures/fixtures.go
+++ b/internal/test/fixtures/fixtures.go
@@ -10,8 +10,9 @@ import (
 
 func NewFeed(opts ...FeedOption) *svc_model.Feed {
 	f := &svc_model.Feed{
-		Name: "test feed name",
-		Url:  "https://example.com/test-feed",
+		Name:     "test feed name",
+		Url:      "https://example.com/test-feed",
+		IsActive: true,
 	}
 	for _, opt := range opts {
 		opt(f)
@@ -36,6 +37,12 @@ func WithFeedName(name string) FeedOption {
 func WithFeedUrl(url string) FeedOption {
 	return func(f *svc_model.Feed) {
 		f.Url = url
+	}
+}
+
+func WithFeedIsActive(isActive bool) FeedOption {
+	return func(f *svc_model.Feed) {
+		f.IsActive = isActive
 	}
 }
 

--- a/mysql/migrations/001_init.up.sql
+++ b/mysql/migrations/001_init.up.sql
@@ -5,6 +5,7 @@ CREATE TABLE `feeds` (
   `deleted_at` datetime(3) DEFAULT NULL,
   `url` longtext,
   `name` longtext,
+  `is_active` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `idx_feeds_deleted_at` (`deleted_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/mysql/migrations/002_data.up.sql
+++ b/mysql/migrations/002_data.up.sql
@@ -4,10 +4,10 @@ LOCK TABLES `feeds` WRITE;
 
 /*!40000 ALTER TABLE `feeds` DISABLE KEYS */;
 
-INSERT INTO `feeds` (`id`, `created_at`, `updated_at`, `deleted_at`, `url`, `name`)
+INSERT INTO `feeds` (`id`, `created_at`, `updated_at`, `deleted_at`, `url`, `name`,`is_active`)
 VALUES
-	("0e597e90-ece5-463e-8608-ff687bf286da",'2024-10-12 13:44:40.000',NULL,NULL,'https://news.ycombinator.com/rss','hacker news'),
-    ("1e597e90-ece5-463e-8608-ff687bf286da",'2024-10-12 13:44:40.000',NULL,NULL,'http://localhost:8388/feeds/atom.xml','example atom.xml');
+	("0e597e90-ece5-463e-8608-ff687bf286da",'2024-10-12 13:44:40.000',NULL,NULL,'https://news.ycombinator.com/rss','hacker news',0),
+    ("1e597e90-ece5-463e-8608-ff687bf286da",'2024-10-12 13:44:40.000',NULL,NULL,'http://localhost:8388/feeds/atom.xml','example atom.xml',0);
 
 /*!40000 ALTER TABLE `feeds` ENABLE KEYS */;
 


### PR DESCRIPTION
- Add default `is_active` filter to feeds
- Add secrets handling for database

Note: tiltfile is a dev env, therefore storing plaintext dev secrets is OK. prod would need something like [sealed secrets](https://www.digitalocean.com/community/developer-center/how-to-encrypt-kubernetes-secrets-using-sealed-secrets-in-doks) or [secrets manager + gke](https://cloud.google.com/secret-manager/docs/secret-manager-managed-csi-component)