### PR TITLE
refactor: observability

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -65,6 +65,10 @@ k8s_resource("graph",
   labels=["app"]
 )
 
+go_compile('echo-compile', './services/echo', ['./services/echo'])
+go_image('echo', './services/echo')
+k8s_resource("echo", port_forwards=[port_forward(8083, 8080, "http")], labels=["services"])
+
 docker_build(
   "ui-image",
   context="./ui",

--- a/containers/lgtm/Dockerfile
+++ b/containers/lgtm/Dockerfile
@@ -8,3 +8,6 @@ COPY prometheus.yaml /otel-lgtm/prometheus.yaml
 # inject amalgam dashboards:
 COPY grafana-dashboards.yaml /otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml
 COPY *-dashboard.json /otel-lgtm/
+
+# copy alerting rules
+COPY grafana/conf/provisioning/alerting/*.yaml /otel-lgtm/grafana/conf/provisioning/alerting/*.yaml

--- a/containers/lgtm/gorm-dashboard.json
+++ b/containers/lgtm/gorm-dashboard.json
@@ -1055,8 +1055,8 @@
     },
     "timepicker": {},
     "timezone": "browser",
-    "title": "api - database",
-    "uid": "api-db-dashboard",
+    "title": "gorm - database",
+    "uid": "gorm-dashboard",
     "version": 1,
     "weekStart": ""
 }

--- a/containers/lgtm/grafana-dashboards.yaml
+++ b/containers/lgtm/grafana-dashboards.yaml
@@ -24,7 +24,7 @@ providers:
   - name: "api database (gorm)"
     type: file
     options:
-      path: /otel-lgtm/api-db-dashboard.json
+      path: /otel-lgtm/gorm-dashboard.json
       foldersFromFilesStructure: false
   - name: "rpc service"
     type: file
@@ -48,7 +48,6 @@ providers:
     options:
       path: /otel-lgtm/temporal-sdk-dashboard.json
       foldersFromFilesStructure: false
-
 
   # TODO: all services overview
   # - name: "Amalgam Dashboard"

--- a/containers/lgtm/grafana/conf/provisioning/alerting/feeds.yaml
+++ b/containers/lgtm/grafana/conf/provisioning/alerting/feeds.yaml
@@ -1,0 +1,67 @@
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: feed workflows
+    folder: feed workflows
+    interval: 30s
+    rules:
+      - uid: feed-workflow-failed-alert
+        title: feed workflow failed
+        condition: A
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 21600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              disableTextWrap: false
+              editorMode: builder
+              expr: feed__temporal_workflow_failed_total
+              fullMetaSearch: false
+              includeNullMetadata: true
+              instant: true
+              intervalMs: 1000
+              legendFormat: __auto
+              maxDataPoints: 43200
+              range: false
+              refId: A
+              useBackend: false
+        noDataState: NoData
+        executionErrorState: Alerting
+        for: 60s
+        labels:
+          team: sre
+        execErrState: Error
+        annotations:
+          summary: Workflow failures detected
+        isPaused: false
+        notification_settings:
+          receiver: echo-webhook
+
+type: webhook
+settings:
+  name: echo-webhook
+  url: http://echo:8080/webhook
+  httpMethod: POST
+  # <string>
+  username: abc
+  # <string>
+  password: abc123
+  # <string>
+  authorization_scheme: Bearer
+  # <string>
+  authorization_credentials: abc123
+  # <string>
+  maxAlerts: "10"
+
+contactPoints:
+  - orgId: 1
+    name: echo-webhook
+    receivers:
+      - uid: echo-webhook
+        type: webhook
+        settings:
+          httpMethod: POST
+          url: http://echo:8080/webhook
+        disableResolveMessage: false

--- a/containers/lgtm/graph-dashboard.json
+++ b/containers/lgtm/graph-dashboard.json
@@ -410,7 +410,7 @@
                         "uid": "prometheus"
                     },
                     "editorMode": "code",
-                    "expr": "graphql_resolver_duration_ms_bucket",
+                    "expr": "graphql_resolver_duration_seconds_bucket",
                     "legendFormat": "{{exitStatus}} - {{object}} - {{field}}",
                     "range": true,
                     "refId": "A"
@@ -492,7 +492,7 @@
                         "uid": "prometheus"
                     },
                     "editorMode": "code",
-                    "expr": "graphql_request_duration_ms_bucket",
+                    "expr": "graphql_request_duration_seconds_bucket",
                     "legendFormat": "{{exitStatus}}",
                     "range": true,
                     "refId": "A"

--- a/containers/lgtm/rpc-dashboard.json
+++ b/containers/lgtm/rpc-dashboard.json
@@ -1448,9 +1448,9 @@
         "list": [
             {
                 "current": {
-                    "selected": false,
-                    "text": "api",
-                    "value": "api"
+                    "selected": true,
+                    "text": "rpc",
+                    "value": "rpc"
                 },
                 "datasource": {
                     "type": "prometheus",
@@ -1595,9 +1595,9 @@
             },
             {
                 "current": {
-                    "selected": false,
-                    "text": "All",
-                    "value": "$__all"
+                    "selected": true,
+                    "text": "feeds.v1.FeedService",
+                    "value": "feeds.v1.FeedService"
                 },
                 "datasource": {
                     "type": "prometheus",
@@ -1651,7 +1651,7 @@
         ]
     },
     "timezone": "",
-    "title": "rpc service",
+    "title": "grpc services",
     "uid": "rpc-service-dashboard",
     "version": 1,
     "weekStart": ""

--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.8 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/helm/templates/echo.yaml
+++ b/helm/templates/echo.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+spec:
+  selector:
+    app: echo
+  ports:
+    - name: echo
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+  labels:
+    app: echo
+spec:
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+        - name: echo
+          image: echo-image
+          ports:
+            - containerPort: 8080

--- a/helm/templates/k6-load-test-graph.yaml
+++ b/helm/templates/k6-load-test-graph.yaml
@@ -13,7 +13,7 @@ spec:
               value: json
             - name: GRAPH_HOST
               value: http://graph:8080/query
-            - name: FAKE_HOST
+            - name: FAKER_HOST
               value: faker:8080
       restartPolicy: Never
   backoffLimit: 4

--- a/helm/templates/lgtm.yaml
+++ b/helm/templates/lgtm.yaml
@@ -46,9 +46,11 @@ spec:
       containers:
         - name: lgtm
           image: lgtm-image
-          # env:
-          #   - name: ENABLE_LOGS_ALL
-          #     value: "true"
+          env:
+            # - name: ENABLE_LOGS_ALL
+            #   value: "true"
+            - name: ENABLE_LOGS_GRAFANA
+              value: "true"
           ports:
             - containerPort: 3000
             - containerPort: 3100

--- a/helm/templates/lgtm.yaml
+++ b/helm/templates/lgtm.yaml
@@ -49,8 +49,8 @@ spec:
           env:
             # - name: ENABLE_LOGS_ALL
             #   value: "true"
-            - name: ENABLE_LOGS_GRAFANA
-              value: "true"
+            # - name: ENABLE_LOGS_GRAFANA
+            #   value: "true"
           ports:
             - containerPort: 3000
             - containerPort: 3100

--- a/k6/load-test-graph/justfile
+++ b/k6/load-test-graph/justfile
@@ -1,4 +1,7 @@
 
 docker:
     docker build -t k6-load-test-graph .
-    docker run -e GRAPH_HOST="http://localhost:8082/query" -it --rm k6-load-test-graph
+    docker run \
+        -e GRAPH_HOST="http://localhost:8082/query" \
+        -e FAKER_HOST="localhost:8084" \
+        -it --rm k6-load-test-graph

--- a/k6/load-test-graph/script.js
+++ b/k6/load-test-graph/script.js
@@ -13,14 +13,14 @@ export let options = {
   ],
 };
 
-const BASE_HOST = __ENV.GRAPH_HOST;
-const FAKE_HOST = __ENV.FAKER_HOST;
+const GRAPH_HOST = __ENV.GRAPH_HOST;
+const FAKER_HOST = __ENV.FAKER_HOST;
 
-if (!BASE_HOST) {
+if (!GRAPH_HOST) {
   throw new Error('GRAPH_HOST is not defined')
 }
-if (!FAKE_HOST) {
-  throw new Error('FAKE_HOST is not defined')
+if (!FAKER_HOST) {
+  throw new Error('FAKER_HOST is not defined')
 }
 
 const DefaultHeaders = {
@@ -52,7 +52,7 @@ export default function () {
 
 function post(body, headers) {
   headers = headers || DefaultHeaders;
-  return http.post(BASE_HOST, JSON.stringify(body), headers);
+  return http.post(GRAPH_HOST, JSON.stringify(body), headers);
 }
 
 function listFeeds() {
@@ -66,7 +66,7 @@ function getFeed(feedId) {
 function addFeed() {
   const feedId = uuidv4();
   const variables = {
-    url: `http://${FAKE_HOST}/feed/${feedId}`,
+    url: `http://${FAKER_HOST}/feed/${feedId}`,
     name: randomString(10, 'abcdefghijklmnopqrstuvwxyz '),
   };
   return { query: MutationAddFeed, variables };

--- a/rpc/internal/server/grpc/grpc_test.go
+++ b/rpc/internal/server/grpc/grpc_test.go
@@ -1,0 +1,13 @@
+package grpc_test
+
+import (
+	"testing"
+
+	"github.com/ericbutera/amalgam/rpc/internal/server/grpc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewServer(t *testing.T) {
+	srv := grpc.NewServer(nil, nil)
+	assert.NotNil(t, srv)
+}

--- a/rpc/internal/server/grpc/interceptors/interceptors.go
+++ b/rpc/internal/server/grpc/interceptors/interceptors.go
@@ -1,0 +1,41 @@
+package interceptors
+
+import (
+	"context"
+
+	"github.com/ericbutera/amalgam/rpc/internal/server/observability"
+	"google.golang.org/grpc"
+)
+
+func UnaryMetricMiddlewareHandler(feedMetrics *observability.FeedMetrics) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+		resp, err = handler(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		ProcessMetrics(info.FullMethod, feedMetrics)
+		return resp, err
+	}
+}
+
+func StreamMetricMiddlewareHandler(feedMetrics *observability.FeedMetrics) grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+		err = handler(srv, stream)
+		if err != nil {
+			return err
+		}
+
+		ProcessMetrics(info.FullMethod, feedMetrics)
+		return err
+	}
+}
+
+func ProcessMetrics(fullMethod string, metrics *observability.FeedMetrics) {
+	switch fullMethod {
+	case "/feeds.v1.FeedService/CreateFeed":
+		metrics.FeedsCreated.Inc()
+	case "/feeds.v1.FeedService/CreateArticle":
+		metrics.ArticlesCreated.Inc()
+	}
+}

--- a/rpc/internal/server/grpc/interceptors/interceptors_test.go
+++ b/rpc/internal/server/grpc/interceptors/interceptors_test.go
@@ -1,0 +1,49 @@
+package interceptors_test
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/ericbutera/amalgam/pkg/feeds/v1"
+	"github.com/ericbutera/amalgam/rpc/internal/server/grpc/interceptors"
+	"github.com/ericbutera/amalgam/rpc/internal/server/observability"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestUnaryMetricMiddlewareHandler(t *testing.T) {
+	o := observability.New()
+	handler := interceptors.UnaryMetricMiddlewareHandler(o.FeedMetrics)
+
+	ctx := context.Background()
+	req := &pb.CreateFeedRequest{}
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/feeds.v1.FeedService/CreateFeed",
+	}
+	_, err := handler(ctx, req, info, func(_ context.Context, _ any) (any, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+	assert.InDelta(t, float64(1.0), testutil.ToFloat64(o.FeedMetrics.FeedsCreated), 0.0001)
+}
+
+type mockServerStream struct {
+	grpc.ServerStream
+}
+
+func TestStreamMetricMiddlewareHandler(t *testing.T) {
+	o := observability.New()
+	handler := interceptors.StreamMetricMiddlewareHandler(o.FeedMetrics)
+
+	stream := &mockServerStream{}
+	info := &grpc.StreamServerInfo{
+		FullMethod: "/feeds.v1.FeedService/CreateArticle",
+	}
+	err := handler(nil, stream, info, func(_ any, _ grpc.ServerStream) error {
+		return nil
+	})
+	require.NoError(t, err)
+	assert.InDelta(t, float64(1.0), testutil.ToFloat64(o.FeedMetrics.ArticlesCreated), 0.0001)
+}

--- a/rpc/internal/server/observability/prom.go
+++ b/rpc/internal/server/observability/prom.go
@@ -9,36 +9,70 @@ import (
 type Observability struct {
 	Registry      *prometheus.Registry
 	ServerMetrics *grpcprom.ServerMetrics
-	// panicsTotal   prometheus.Counter
+	FeedMetrics   *FeedMetrics
 }
 
 func New() *Observability {
 	registry := prometheus.NewRegistry()
-	srvMetrics := newServerMetrics()
 
-	registry.MustRegister(srvMetrics)
 	registry.MustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics()))
 
-	// TODO: server.newPromMetrics(registry)
-
-	return &Observability{
+	o := &Observability{
 		Registry:      registry,
-		ServerMetrics: srvMetrics,
+		ServerMetrics: newServerMetrics(registry),
+		FeedMetrics:   getFeedMetrics(registry),
 	}
+
+	return o
 }
 
-func newServerMetrics() *grpcprom.ServerMetrics {
-	return grpcprom.NewServerMetrics(
+func newServerMetrics(r *prometheus.Registry) *grpcprom.ServerMetrics {
+	m := grpcprom.NewServerMetrics(
 		grpcprom.WithServerHandlingTimeHistogram(
 			grpcprom.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
 		),
 	)
+	r.MustRegister(m)
+	return m
 }
 
-// TODO:
-// func (s *Server) newPromMetrics(reg prometheus.Registerer) {
-// 	s.panicsTotal = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-// 		Name: "grpc_req_panics_recovered_total",
-// 		Help: "Total number of gRPC requests recovered from internal panic.",
-// 	})
-// }
+type FeedMetrics struct {
+	ArticlesCreated prometheus.Counter
+	FeedsCreated    prometheus.Counter
+	PanicsTotal     prometheus.Counter
+}
+
+func getFeedMetrics(r *prometheus.Registry) *FeedMetrics {
+	// TODO: move this into New() and use Options pattern?
+	// TODO: refactor- seems to be a candidate for a metrics package
+	// TODO: if register is called multiple times it will fail
+
+	// According to [Practical Monitoring](https://learning.oreilly.com/library/view/practical-monitoring/9781491957349/ch05.html#Monitoring_the_Business)
+	// business KPIs can help guide metric creation. this app is an aggregator,
+	// we can see if "things are working" by tracking feed & article creation.
+	articlesCreated := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:      "articles_created_total",
+		Namespace: "rpc",
+		Help:      "Total number of articles created.",
+	})
+	feedsCreated := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:      "feeds_created_total",
+		Namespace: "rpc",
+		Help:      "Total number of feeds created.",
+	})
+	panicsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:      "panics_recovered_total",
+		Namespace: "rpc",
+		Help:      "Total number of panics recovered.",
+	})
+
+	r.MustRegister(articlesCreated)
+	r.MustRegister(feedsCreated)
+	r.MustRegister(panicsTotal)
+
+	return &FeedMetrics{
+		ArticlesCreated: articlesCreated,
+		FeedsCreated:    feedsCreated,
+		PanicsTotal:     panicsTotal,
+	}
+}

--- a/rpc/internal/server/observability/prom.go
+++ b/rpc/internal/server/observability/prom.go
@@ -14,7 +14,6 @@ type Observability struct {
 
 func New() *Observability {
 	registry := prometheus.NewRegistry()
-
 	registry.MustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics()))
 
 	o := &Observability{

--- a/rpc/internal/server/observability/prom_test.go
+++ b/rpc/internal/server/observability/prom_test.go
@@ -1,0 +1,26 @@
+package observability_test
+
+import (
+	"testing"
+
+	"github.com/ericbutera/amalgam/rpc/internal/server/observability"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeedMetrics(t *testing.T) {
+	o := observability.New()
+	feedMetrics := o.FeedMetrics
+	assert.NotNil(t, feedMetrics.ArticlesCreated)
+	assert.NotNil(t, feedMetrics.FeedsCreated)
+	assert.NotNil(t, feedMetrics.PanicsTotal)
+}
+
+func TestFeedMetrics_ArticlesCreated(t *testing.T) {
+	o := observability.New()
+	feedMetrics := o.FeedMetrics
+
+	initialValue := testutil.ToFloat64(feedMetrics.ArticlesCreated)
+	feedMetrics.ArticlesCreated.Inc()
+	assert.InDelta(t, initialValue+1, testutil.ToFloat64(feedMetrics.ArticlesCreated), 0.0001)
+}

--- a/rpc/internal/server/server.go
+++ b/rpc/internal/server/server.go
@@ -135,13 +135,13 @@ func WithGrpcServer(srv *grpc.Server) Option {
 func New(opts ...Option) (*Server, error) {
 	server := Server{}
 
-	o := observability.New()
-
 	for _, opt := range opts {
 		if err := opt(&server); err != nil {
 			return nil, err
 		}
 	}
+
+	o := observability.New() // TODO: with Options
 
 	if server.config == nil {
 		config, err := env.New[config.Config]()
@@ -161,7 +161,7 @@ func New(opts ...Option) (*Server, error) {
 		server.metricSrv = metrics_server.NewServer(o.Registry, server.config.MetricAddress)
 	}
 	if server.grpcSrv == nil {
-		server.grpcSrv = grpc_server.NewServer(o.ServerMetrics)
+		server.grpcSrv = grpc_server.NewServer(o.ServerMetrics, o.FeedMetrics)
 	}
 
 	pb.RegisterFeedServiceServer(server.grpcSrv, &server)

--- a/rpc/internal/server/server.go
+++ b/rpc/internal/server/server.go
@@ -141,7 +141,7 @@ func New(opts ...Option) (*Server, error) {
 		}
 	}
 
-	o := observability.New() // TODO: with Options
+	o := observability.New()
 
 	if server.config == nil {
 		config, err := env.New[config.Config]()

--- a/services/echo/main.go
+++ b/services/echo/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/ericbutera/amalgam/internal/http/server"
+	"github.com/samber/lo"
+)
+
+func webhookHandler(w http.ResponseWriter, r *http.Request) {
+	slog.Info("Received webhook",
+		"method", r.Method,
+		"url", r.URL,
+		"remote_addr", r.RemoteAddr,
+		"user_agent", r.UserAgent(),
+		"content_length", r.ContentLength,
+	)
+
+	var payload map[string]any
+	err := json.NewDecoder(r.Body).Decode(&payload)
+	if err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		slog.Error("Failed to marshal payload", "error", err)
+		http.Error(w, "Error processing request", http.StatusInternalServerError)
+		return
+	}
+	lo.Must(fmt.Printf("headers: %+v\n", r.Header))
+	lo.Must(fmt.Printf("payload: %s\n", string(data)))
+
+	w.WriteHeader(http.StatusOK)
+	if _, err := fmt.Fprintln(w, "Alert received"); err != nil {
+		slog.Error("Failed to write response", "error", err)
+	}
+}
+
+func main() {
+	http.HandleFunc("/webhook", webhookHandler)
+
+	port := "8080"
+	slog.Info("Webhook receiver is running", "port", port)
+
+	server := lo.Must(server.New())
+	err := server.ListenAndServe()
+	if err != nil {
+		slog.Error("Failed to start server", "error", err)
+	}
+}


### PR DESCRIPTION
I did not want to add any external services or add more things like httpbin to show webhooks in this project. In the real world these would go to slack or pagerduty.

Changes:

- create fake "echo-webhook" service to print incoming request
- copy alert yaml files into lgtm image
- create feed workflow alert on failed workflows
- alerts go to "echo-webhook" service
- fix dashboards (broke over time :))
- add custom metrics to rpc