### PR TITLE
refactor: ease of use

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,5 +21,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.62
           args: --timeout=5m --config=.golangci.yaml

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -93,5 +93,6 @@ issues:
   exclude-files:
     - ".*\\.pb\\.go$"
     - pkg/feeds/v1/service_grpc.pb.go
+    - internal/copygen/generated.go
   whole-files: true
   fix: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,8 +2,6 @@
 linters:
   enable-all: true
   disable:
-    - execinquery
-    - gomnd
     - exportloopref
     - godot
     - godox
@@ -62,6 +60,8 @@ linters-settings:
       - name: unused-receiver
         exclude:
           - graph/extensions/prometheus/prometheus.go
+      - name: max-public-structs
+        disabled: true
       # - name: var-naming
       #   severity: warning
       #   disabled: false
@@ -90,9 +90,13 @@ issues:
     - path: cli/
       linters:
         - revive
+    - path: graph/graph/schema.resolvers_test.go
+      linters:
+        - revive
   exclude-files:
     - ".*\\.pb\\.go$"
     - pkg/feeds/v1/service_grpc.pb.go
     - internal/copygen/generated.go
+    - graph/extensions/prometheus/prometheus.go
   whole-files: true
   fix: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,11 +3,10 @@ linters:
   enable-all: true
   disable:
     - exportloopref
-    - godot
-    - godox
+    - godot # adds period at end of comments (no thanks)
+    - godox # bans TODO
     - exhaustruct
     - depguard
-    - gochecknoinits
     - nlreturn
     - gomoddirectives
     - wsl

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,15 +9,14 @@ linters:
     - depguard
     - nlreturn
     - gomoddirectives
-    - wsl
+    - wsl # only one cuddle assignment allowed before range statement
     - wrapcheck
     - nonamedreturns # i like these sometimes
     - paralleltest
     - varnamelen
-    - ireturn
-    - tagliatelle
+    - ireturn # not allowed to return interfaces
+    - tagliatelle # json(camel): got 'feed_id' want 'feedId'
     - gochecknoglobals
-    - inamedparam
     - interfacebloat
     - perfsprint
     - nilnil
@@ -93,5 +92,6 @@ issues:
     - pkg/feeds/v1/service_grpc.pb.go
     - internal/copygen/generated.go
     - graph/extensions/prometheus/prometheus.go
+    - internal/copygen/setup.go
   whole-files: true
   fix: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,13 +17,12 @@ linters:
     - varnamelen
     - ireturn
     - tagliatelle
-    - forbidigo
     - gochecknoglobals
     - inamedparam
     - interfacebloat
     - perfsprint
     - nilnil
-    - stylecheck
+    - stylecheck # feedId -> feedID
     - thelper
     - forcetypeassert
     - mnd

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,7 +29,6 @@ linters:
     - mnd
     - intrange
     - lll
-    - gocritic
 
 linters-settings:
   tagalign:
@@ -58,6 +57,8 @@ linters-settings:
         exclude:
           - graph/extensions/prometheus/prometheus.go
       - name: max-public-structs
+        disabled: true
+      - name: comment-spacings
         disabled: true
       # - name: var-naming
       #   severity: warning

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,7 @@ linters:
     - gomoddirectives
     - wsl
     - wrapcheck
-    - nonamedreturns
+    - nonamedreturns # i like these sometimes
     - paralleltest
     - varnamelen
     - ireturn
@@ -24,8 +24,7 @@ linters:
     - stylecheck # feedId -> feedID
     - thelper
     - forcetypeassert
-    - mnd
-    - intrange
+    - intrange # for x := 0; x < count; x++ -> for x := range make([]int, count)
     - lll
 
 linters-settings:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,7 +22,6 @@ linters:
     - nilnil
     - stylecheck # feedId -> feedID
     - thelper
-    - forcetypeassert
     - intrange # for x := 0; x < count; x++ -> for x := range make([]int, count)
     - lll
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,11 +28,9 @@ linters:
     - forcetypeassert
     - mnd
     - intrange
-    - errorlint
     - err113
     - lll
     - gocritic
-    - exhaustive
 
 linters-settings:
   tagalign:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,7 +28,6 @@ linters:
     - forcetypeassert
     - mnd
     - intrange
-    - err113
     - lll
     - gocritic
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ tilt up
 # open tilt ui @ http://localhost:10350
 ```
 
+## Development
+
+[Development](./docs/development.md) contains an overview of how to develop the various components of the application.
+
 ## Architecture
 
 [Architecture](./docs/architecture.md) contains an overview of how to convert a project from a monolith to a microservices architecture.

--- a/amalgam-cli/cmd/feed.go
+++ b/amalgam-cli/cmd/feed.go
@@ -42,7 +42,7 @@ func NewFeedListCmd() *cobra.Command {
 			}
 			slog.Debug("feed count", "feeds", len(res.Feeds))
 			for _, feed := range res.Feeds {
-				fmt.Printf("feed id: %s, url: %s\n", feed.Id, feed.Url)
+				fmt.Printf("feed id: %s, url: %s\n", feed.Id, feed.Url) //nolint:forbidigo
 			}
 		},
 	}

--- a/amalgam-cli/cmd/feed.go
+++ b/amalgam-cli/cmd/feed.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -10,6 +11,8 @@ import (
 	client "github.com/ericbutera/amalgam/pkg/clients/graphql"
 	"github.com/spf13/cobra"
 )
+
+var ErrInvalidURL = errors.New("invalid URL specified")
 
 func NewFeedCmd() *cobra.Command {
 	return &cobra.Command{
@@ -57,7 +60,7 @@ func NewFeedAddCmd() *cobra.Command {
 			if err == nil && u.Scheme != "" && u.Host != "" {
 				return nil
 			}
-			return fmt.Errorf("invalid URL specified: %s", args[0])
+			return ErrInvalidURL
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			slog.Info("feed add!", "url", args[0])

--- a/amalgam-cli/cmd/root.go
+++ b/amalgam-cli/cmd/root.go
@@ -19,7 +19,7 @@ func Execute() {
 	os.Exit(0)
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	feedCmd := NewFeedCmd()
 	feedCmd.AddCommand(NewFeedListCmd())
 	feedCmd.AddCommand(NewFeedAddCmd())

--- a/api/cmd/root.go
+++ b/api/cmd/root.go
@@ -18,6 +18,6 @@ func Execute() {
 	}
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	rootCmd.AddCommand(NewServerCmd())
 }

--- a/api/cmd/server.go
+++ b/api/cmd/server.go
@@ -19,6 +19,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var ErrHostNotSet = errors.New("host not set")
+
 func NewServerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "server",
@@ -82,7 +84,7 @@ func runServer(cmd *cobra.Command, args []string) {
 
 func newGraphClient(host string, logger *slog.Logger) (graphql.Client, error) {
 	if host == "" {
-		return nil, errors.New("graph host not set")
+		return nil, ErrHostNotSet
 	}
 	httpClient := http.Client{
 		Transport: transport.NewLoggingTransport(

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	// log level
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	viper.SetDefault("cors_allow_origins", []string{})
 	viper.SetDefault("cors_allow_methods", []string{})
 	viper.SetDefault("cors_allow_headers", []string{})

--- a/api/internal/server/metrics.go
+++ b/api/internal/server/metrics.go
@@ -6,7 +6,6 @@ func (s *server) metrics() {
 	// https://github.com/penglongli/gin-metrics
 	m := ginmetrics.GetMonitor()
 	m.SetMetricPath("/metrics")
-	m.SetSlowTime(10)                              // +optional set slow time, default 5s
 	m.SetDuration([]float64{0.1, 0.3, 1.2, 5, 10}) // +optional set request duration, default {0.1, 0.3, 1.2, 5, 10} // used to p95, p99
 	m.Use(s.router)
 }

--- a/api/internal/server/middleware.go
+++ b/api/internal/server/middleware.go
@@ -12,6 +12,8 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 )
 
+const MaxAge = 12 * time.Hour
+
 var ignoredRoutes = []string{
 	"/metrics",
 	"/health",
@@ -42,7 +44,7 @@ func corsMiddleware(cfg *config.Config) gin.HandlerFunc {
 		AllowHeaders:     cfg.CorsAllowHeaders,
 		ExposeHeaders:    cfg.CorsExposeHeaders,
 		AllowCredentials: true,
-		MaxAge:           12 * time.Hour,
+		MaxAge:           MaxAge,
 	})
 }
 

--- a/data-pipeline/temporal/feed/activity_test.go
+++ b/data-pipeline/temporal/feed/activity_test.go
@@ -114,7 +114,9 @@ func TestParseActivity(t *testing.T) {
 		expected, err := parse.Parse(reader)
 		require.NoError(t, err)
 
-		actual := dataToArticles(t, data.(io.Reader))
+		r, ok := data.(io.Reader)
+		require.True(t, ok)
+		actual := dataToArticles(t, r)
 		compareArticles(t, expected, actual)
 		return true
 	})

--- a/data-pipeline/temporal/feed/internal/config/config.go
+++ b/data-pipeline/temporal/feed/internal/config/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	MinioRegion          string `mapstructure:"minio_region"`
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	viper.SetDefault("feed_use_schedule", false)
 	viper.SetDefault("feed_schedule_id", "feed-schedule-id")
 	viper.SetDefault("feed_workflow_id", "feed-workflow-id")

--- a/data-pipeline/temporal/feed/worker/main.go
+++ b/data-pipeline/temporal/feed/worker/main.go
@@ -51,6 +51,6 @@ func main() {
 	err := w.Run(worker.InterruptCh())
 	if err != nil {
 		slog.Error("unable to start worker", "error", err)
-		os.Exit(1)
+		os.Exit(1) //nolint: gocritic
 	}
 }

--- a/data-pipeline/temporal/feed_tasks/config.go
+++ b/data-pipeline/temporal/feed_tasks/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	TemporalHost  string `mapstructure:"temporal_host"`
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	viper.SetDefault("feed_tasks_count", 25)
 	viper.SetDefault("feed_tasks_workflow_id", "feed-tasks-feeds")
 	viper.SetDefault("feed_tasks_task_queue", "feed-tasks-feeds-queue")

--- a/data-pipeline/temporal/feed_tasks/config.go
+++ b/data-pipeline/temporal/feed_tasks/config.go
@@ -14,7 +14,7 @@ type Config struct {
 }
 
 func init() { //nolint:gochecknoinits
-	viper.SetDefault("feed_tasks_count", 25)
+	viper.SetDefault("feed_tasks_count", 25) //nolint:mnd
 	viper.SetDefault("feed_tasks_workflow_id", "feed-tasks-feeds")
 	viper.SetDefault("feed_tasks_task_queue", "feed-tasks-feeds-queue")
 	viper.SetDefault("fake_host", "")

--- a/data-pipeline/temporal/feed_tasks/start/main.go
+++ b/data-pipeline/temporal/feed_tasks/start/main.go
@@ -33,7 +33,7 @@ func main() {
 	we, err := client.ExecuteWorkflow(ctx, opts, feed_tasks.GenerateFeedsWorkflow, config.FakeHost, config.GenerateCount)
 	if err != nil {
 		slog.Error("unable to execute workflow", "error", err)
-		os.Exit(1)
+		os.Exit(1) //nolint: gocritic
 	}
 	slog.Info("started workflow", "workflow_id", we.GetID())
 }

--- a/data-pipeline/temporal/feed_tasks/worker/main.go
+++ b/data-pipeline/temporal/feed_tasks/worker/main.go
@@ -28,6 +28,6 @@ func main() {
 	err := w.Run(worker.InterruptCh())
 	if err != nil {
 		slog.Error("unable to start worker", "error", err)
-		os.Exit(1)
+		os.Exit(1) //nolint: gocritic
 	}
 }

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -10,6 +10,17 @@ You can find the [copygen transforms here](https://github.com/ericbutera/amalgam
 
 ## GraphQL
 
+General workflow:
+
+- run tilt `tilt up`
+- change server schema `graph/graph/schema.graphqls`
+- generate server `just generate-graph-server`
+- await graph service to hot-reload
+- generate schema `just generate-graph-schema`
+- generate clients `just generate-graph-clients`
+
+This is not an optimal solution. I intend to have it so these steps are automated without a Tilt dependency.
+
 ### Server
 
 The GraphQL server can be generated using `just generate-graph-server` ([source](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/justfile#L144-L148)).
@@ -22,8 +33,10 @@ The GraphQL [schema](https://github.com/ericbutera/amalgam/tree/ad3d798390308898
 
 These generated clients provide strongly typed interfaces, enhancing developer experience with code completion and preventing runtime errors.
 
-- [TypeScript](https://github.com/ericbutera/amalgam/blob/9528beb51c6b2affa3b6bd1622ca666983148fc4/ui/app/generated/graphql.ts#L204-L225) via [`generate-graph-ts-client`](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/justfile#L165-L169)
-- [Go](https://github.com/ericbutera/amalgam/blob/9528beb51c6b2affa3b6bd1622ca666983148fc4/pkg/clients/graphql/graphql.gen.go) via [`generate-graph-golang-client`](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/justfile#L159-L162)
+| Client | Command |
+| --- | --- |
+| [TypeScript](https://github.com/ericbutera/amalgam/blob/9528beb51c6b2affa3b6bd1622ca666983148fc4/ui/app/generated/graphql.ts#L204-L225) | [`generate-graph-ts-client`](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/justfile#L165-L169) |
+| [Go](https://github.com/ericbutera/amalgam/blob/9528beb51c6b2affa3b6bd1622ca666983148fc4/pkg/clients/graphql/graphql.gen.go) | [`generate-graph-golang-client`](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/justfile#L159-L162) |
 
 ## OpenAPI Clients ([v1.3.1](https://github.com/ericbutera/amalgam/releases/tag/v1.3.1))
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -1,13 +1,5 @@
 # Code Generation
 
-## Copygen
-
-[Copygen](https://github.com/switchupcb/copygen) is a powerful tool designed to simplify a common development task: transferring data between structs. This is especially useful when adhering to best practices like separating concerns in layered architectures (e.g., GraphQL, gRPC, and data layers).
-
-By automating the generation of code for copying fields between structs with similar structures, Copygen significantly reduces development time and effort. This allows developers to focus on core business logic, while the tool handles the repetitive and error-prone task of manual data mapping."
-
-You can find the [copygen transforms here](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/internal/copygen/setup.go#L12-L41).
-
 ## GraphQL
 
 General workflow:
@@ -21,15 +13,7 @@ General workflow:
 
 This is not an optimal solution. I intend to have it so these steps are automated without a Tilt dependency.
 
-### Server
-
-The GraphQL server can be generated using `just generate-graph-server` ([source](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/justfile#L144-L148)).
-
-### Schema
-
-The GraphQL [schema](https://github.com/ericbutera/amalgam/tree/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/tools/graphql-schema) is generated using `just generate-graph-schema` ([source](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/justfile#L151-L156)).
-
-### Clients (post [v1.4.0](https://github.com/ericbutera/amalgam/releases/tag/v1.4.0))
+### Clients ([v1.4.0](https://github.com/ericbutera/amalgam/releases/tag/v1.4.0))
 
 These generated clients provide strongly typed interfaces, enhancing developer experience with code completion and preventing runtime errors.
 
@@ -38,9 +22,17 @@ These generated clients provide strongly typed interfaces, enhancing developer e
 | [TypeScript](https://github.com/ericbutera/amalgam/blob/9528beb51c6b2affa3b6bd1622ca666983148fc4/ui/app/generated/graphql.ts#L204-L225) | [`generate-graph-ts-client`](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/justfile#L165-L169) |
 | [Go](https://github.com/ericbutera/amalgam/blob/9528beb51c6b2affa3b6bd1622ca666983148fc4/pkg/clients/graphql/graphql.gen.go) | [`generate-graph-golang-client`](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/justfile#L159-L162) |
 
-## OpenAPI Clients ([v1.3.1](https://github.com/ericbutera/amalgam/releases/tag/v1.3.1))
+## (deprecated) OpenAPI Clients ([v1.3.1](https://github.com/ericbutera/amalgam/releases/tag/v1.3.1))
 
 - [OpenAPI spec](https://github.com/ericbutera/amalgam/blob/8c4e26f23ecd3af6c7eae80cbb1a16165fcd1703/api/docs/swagger.yaml) with [swaggo/swag](https://github.com/swaggo/swag)
 - [REST client](https://github.com/ericbutera/amalgam/tree/8c4e26f23ecd3af6c7eae80cbb1a16165fcd1703/pkg/client) from OpenAPI spec
 - [TypeScript client](https://github.com/ericbutera/amalgam/tree/8c4e26f23ecd3af6c7eae80cbb1a16165fcd1703/ui/app/lib/client) from OpenAPI spec
 - [k6 tests](https://github.com/ericbutera/amalgam/tree/main/k6/tests/openapi) from OpenAPI spec
+
+## Copygen
+
+[Copygen](https://github.com/switchupcb/copygen) is a powerful tool designed to simplify a common development task: transferring data between structs. This is especially useful when adhering to best practices like separating concerns in layered architectures (e.g., GraphQL, gRPC, and data layers).
+
+By automating the generation of code for copying fields between structs with similar structures, Copygen significantly reduces development time and effort. This allows developers to focus on core business logic, while the tool handles the repetitive and error-prone task of manual data mapping."
+
+You can find the [copygen transforms here](https://github.com/ericbutera/amalgam/blob/ad3d79839030889826a8fb2f0c0dcad48bf9d06e/internal/copygen/setup.go#L12-L41).

--- a/docs/code-quality.md
+++ b/docs/code-quality.md
@@ -8,6 +8,6 @@ just setup
 
 ## Linters
 
-- [golangci-lint](https://golangci-lint.run/) - golang linters
+- [golangci-lint](https://golangci-lint.run/) - golang linters (config in [.golangci.yml](../.golangci.yaml))
 - [eslint](https://eslint.org/) - typescript linters
 - [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) - enforced by pre-commit hooks

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,99 @@
+# Development Guide
+
+## Prerequisites
+
+- [docker desktop](https://docs.docker.com/desktop/) + [docker kubernetes](https://docs.docker.com/desktop/features/kubernetes/)
+- [asdf-vm](https://asdf-vm.com/) - easily manage third party tools; this is not a hard requirement, but all of the commands things in [.tool-versions](../.tool-versions) are used throughout local development.
+- [tilt](https://tilt.dev/) - local development orchestrator
+
+## Tilt
+
+Tilt is the local development orchestrator. The [Tiltfile](../Tiltfile) configures services, dependencies and build steps.
+
+## Local Debugging
+
+I like to debug locally using by turning off specific services in Tilt and running them locally in VSCode.
+
+example `.vscode/launch.json`:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "graph",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "graph/main.go",
+      "envFile": "${workspaceFolder}/.env",
+      "args": ["server"]
+    },
+    {
+      "name": "rpc",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "rpc/main.go",
+      "env": {
+        "PORT": "50055",
+        "METRIC_ADDRESS": ":9091",
+        "DB_ADAPTER": "sqlite"
+      },
+      "envFile": "${workspaceFolder}/.env",
+      "args": ["server"]
+    },
+    {
+      "name": "temporal - fetch feed - worker",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "data-pipeline/temporal/feed/worker/main.go",
+      "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "name": "temporal - generate feed - worker",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "data-pipeline/temporal/generate/worker/main.go",
+      "envFile": "${workspaceFolder}/.env"
+    }
+  ]
+}
+```
+
+example `.vscode/settings.json`:
+
+```json
+{
+  "go.testEnvFile": "${workspaceFolder}/.env"
+}
+```
+
+example `.env`:
+
+```sh
+# FAKE_HOST=localhost:8084
+FAKE_HOST=faker:8080
+GRAPH_HOST="http://localhost:8082/query"
+GRAPH_PORT=8082
+RPC_HOST=localhost:50055
+RPC_INSECURE=true
+TEMPORAL_HOST=localhost:7233
+MINIO_ENDPOINT=localhost:9100
+MINIO_USE_SSL=false
+MINIO_ACCESS_KEY=minio
+MINIO_SECRET_ACCESS_KEY=minio-password
+OTEL_ENABLE=true
+OTEL_SERVICE_NAME=feed-worker
+OTEL_EXPORTER_OTLP_INSECURE=true
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+USE_SCHEDULE=false
+FEED_SCHEDULE_ID=feed-worker
+FEED_WORKFLOW_ID=feed-worker
+CORS_ALLOW_ORIGINS=http://localhost:3000
+CORS_ALLOW_METHODS=GET,POST,PUT
+CORS_ALLOW_HEADERS=Content-Type,Authorization,Origin
+CORS_EXPOSE_HEADERS=Content-Length
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,8 +3,8 @@
 ## Prerequisites
 
 - [docker desktop](https://docs.docker.com/desktop/) + [docker kubernetes](https://docs.docker.com/desktop/features/kubernetes/)
-- [asdf-vm](https://asdf-vm.com/) - easily manage third party tools; this is not a hard requirement, but all of the commands things in [.tool-versions](../.tool-versions) are used throughout local development.
-- [tilt](https://tilt.dev/) - local development orchestrator
+- [asdf-vm](https://asdf-vm.com/) - easily manage third party tools (or manually install things listed in [.tool-versions](../.tool-versions)).
+- [tilt](https://tilt.dev/) - local development orchestrator (installed via asdf).
 
 ## Tilt
 
@@ -12,7 +12,7 @@ Tilt is the local development orchestrator. The [Tiltfile](../Tiltfile) configur
 
 ## Local Debugging
 
-I like to debug locally using by turning off specific services in Tilt and running them locally in VSCode.
+I like to debug locally in VScode. For example, to debug RPC, first turn off theRPC service in Tilt. Next, run the rpc launch profile. The `.env` file defines environment variables that match the port forwards in Tilt.
 
 example `.vscode/launch.json`:
 

--- a/graph/cmd/schema/main.go
+++ b/graph/cmd/schema/main.go
@@ -1,0 +1,44 @@
+// minimal server that serves only the graphql schema
+// intended to be used with generate schema
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/ericbutera/amalgam/graph/graph"
+	"github.com/ericbutera/amalgam/internal/http/server"
+	"github.com/go-chi/chi"
+	"github.com/samber/lo"
+)
+
+const (
+	DefaultPort  = ":8082"
+	DefaultRoute = "/query"
+)
+
+func main() {
+	addr := os.Getenv("GRAPH_ADDR")
+	if addr == "" {
+		addr = ":8082"
+	}
+	srv := handler.NewDefaultServer(
+		graph.NewExecutableSchema(graph.Config{
+			Resolvers: graph.NewResolver(nil),
+		}),
+	)
+
+	router := chi.NewRouter()
+	router.Handle(DefaultRoute, srv)
+
+	server := lo.Must(server.New(
+		server.WithAddr(addr),
+		server.WithHandler(router),
+	))
+	slog.Info("running server", "addr", addr, "route", DefaultRoute)
+	if err := server.ListenAndServe(); err != nil {
+		slog.Error("graph server error", "error", err)
+		return
+	}
+}

--- a/graph/internal/config/config.go
+++ b/graph/internal/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	CorsExposeHeaders []string `mapstructure:"cors_expose_headers"`
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	viper.SetDefault("graph_port", "8080")
 	viper.SetDefault("rpc_host", "rpc:50051")
 	viper.SetDefault("rpc_insecure", false)

--- a/graph/internal/convert/validation.go
+++ b/graph/internal/convert/validation.go
@@ -1,3 +1,4 @@
+//nolint:err113
 package convert
 
 import (

--- a/graph/main.go
+++ b/graph/main.go
@@ -63,7 +63,7 @@ func main() {
 	))
 	if err := server.ListenAndServe(); err != nil {
 		slog.Error("failed to start server", "error", err)
-		os.Exit(1)
+		os.Exit(1) //nolint: gocritic
 		return
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -15,6 +15,8 @@ import (
 	"gorm.io/plugin/opentelemetry/tracing"
 )
 
+var ErrInvalidAdapter = errors.New("invalid adapter")
+
 type Adapters string
 
 const (
@@ -61,7 +63,7 @@ func NewFromConfig(config *Config) (*gorm.DB, error) {
 			WithTraceAll(),
 		)
 	}
-	return nil, errors.New("db adapter not supported")
+	return nil, ErrInvalidAdapter
 }
 
 func setOpts(db *gorm.DB, opts ...Options) error {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -35,7 +35,7 @@ type Config struct {
 	DbSqliteName string   `mapstructure:"db_sqlite_name"`
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	viper.SetDefault("db_adapter", SqliteAdapter)
 	viper.SetDefault("db_sqlite_name", "file::memory:?cache=shared")
 	viper.SetDefault("db_mysql_dsn", "user:pass@tcp(127.0.0.1:3306)/dbname?charset=utf8mb4&parseTime=True&loc=Local")

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -138,9 +138,7 @@ func WithSeedData() Options {
 }
 
 func WithMiddleware() Options {
-	return func(db *gorm.DB) error {
-		return middleware(db)
-	}
+	return middleware
 }
 
 func middleware(db *gorm.DB) error {

--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -7,6 +7,8 @@ import (
 	sanitizer "github.com/go-sanitize/sanitize"
 )
 
+var ErrInvalidURL = errors.New("invalid URL specified")
+
 // Returns a sanitized copy of the original data.
 func Struct[T any](data T) (T, error) {
 	s, err := sanitizer.New(
@@ -30,7 +32,7 @@ func sanitizeUrl(_ sanitizer.Sanitizer, structValue reflect.Value, idx int) erro
 	fieldValue := structValue.Field(idx)
 	url, err := Url(fieldValue.String())
 	if err != nil {
-		return errors.New("invalid url")
+		return ErrInvalidURL
 	}
 	fieldValue.SetString(url)
 	return nil

--- a/internal/service/gorm.go
+++ b/internal/service/gorm.go
@@ -15,6 +15,8 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+const DefaultLimit = 100
+
 var ErrQueryFailed = errors.New("query failed")
 
 type GormService struct {
@@ -34,7 +36,7 @@ func (s *GormService) Feeds(ctx context.Context) ([]svc_model.Feed, error) {
 	var feeds []svc_model.Feed
 	result := s.query(ctx).
 		Where("is_active=?", true).
-		Limit(100). // TODO: pagination
+		Limit(DefaultLimit). // TODO: pagination
 		Find(&feeds)
 
 	if result.Error != nil {
@@ -147,7 +149,7 @@ func (s *GormService) GetFeed(ctx context.Context, id string) (*svc_model.Feed, 
 func (s *GormService) GetArticlesByFeed(ctx context.Context, feedId string) ([]svc_model.Article, error) {
 	var articles []svc_model.Article
 	result := s.query(ctx).
-		Limit(100). // TODO: pagination (cursor)
+		Limit(DefaultLimit). // TODO: pagination (cursor)
 		Find(&articles, "feed_id=?", feedId)
 
 	if result.Error != nil {

--- a/internal/service/gorm.go
+++ b/internal/service/gorm.go
@@ -15,6 +15,8 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+var ErrQueryFailed = errors.New("query failed")
+
 type GormService struct {
 	db *gorm.DB
 }
@@ -36,7 +38,7 @@ func (s *GormService) Feeds(ctx context.Context) ([]svc_model.Feed, error) {
 		Find(&feeds)
 
 	if result.Error != nil {
-		return nil, errors.New("failed to fetch feeds")
+		return nil, ErrQueryFailed
 	}
 	return feeds, nil
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-playground/validator/v10"
@@ -29,8 +30,9 @@ func Struct(data any, customMessages CustomMessages) ValidationResult {
 	err := validate.Struct(data)
 	if err != nil {
 		var errs []ValidationError
-		if errors, ok := err.(validator.ValidationErrors); ok {
-			for _, err := range errors {
+		var validationErrors validator.ValidationErrors
+		if errors.As(err, &validationErrors) {
+			for _, err := range validationErrors {
 				fieldTag := fmt.Sprintf("%s.%s", err.StructField(), err.Tag())
 				errs = append(errs, ValidationError{
 					Field:           err.StructField(),

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -12,11 +12,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
+var ErrInvalidPath = errors.New("invalid path")
+
 func GetTestDataPath(datafile string) (string, error) {
 	// https://hackandsla.sh/posts/2020-11-23-golang-test-fixtures/
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
-		return "", errors.New("unable to discover path")
+		return "", ErrInvalidPath
 	}
 	return path.Join(path.Dir(filename), "..", "..", "testdata", datafile), nil
 }

--- a/rpc/internal/config/config.go
+++ b/rpc/internal/config/config.go
@@ -9,7 +9,7 @@ type Config struct {
 	MetricAddress string `mapstructure:"metric_address"` // metric server address
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	viper.SetDefault("port", "8080")
 	viper.SetDefault("metric_address", ":9090")
 }

--- a/rpc/internal/server/metrics/metrics.go
+++ b/rpc/internal/server/metrics/metrics.go
@@ -8,6 +8,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const Timeout = 10 * time.Second
+
 func NewServer(registry *prometheus.Registry, address string) *http.Server {
 	m := http.NewServeMux()
 	m.Handle("/metrics", promhttp.HandlerFor(
@@ -19,6 +21,6 @@ func NewServer(registry *prometheus.Registry, address string) *http.Server {
 	return &http.Server{
 		Addr:              address,
 		Handler:           m,
-		ReadHeaderTimeout: 10 * time.Second,
+		ReadHeaderTimeout: Timeout,
 	}
 }

--- a/rpc/internal/server/procs.go
+++ b/rpc/internal/server/procs.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var ErrInvalidTaskType = errors.New("invalid task type")
+
 func (s *Server) ListFeeds(ctx context.Context, _ *pb.ListFeedsRequest) (*pb.ListFeedsResponse, error) {
 	feeds, err := s.service.Feeds(ctx)
 	if err != nil {
@@ -144,7 +146,7 @@ func pbTaskToTaskType(task pb.FeedTaskRequest_Task) (tasks.TaskType, error) {
 	if task == pb.FeedTaskRequest_TASK_GENERATE_FEEDS {
 		return tasks.TaskGenerateFeeds, nil
 	}
-	return tasks.TaskUnspecified, errors.New("invalid task type")
+	return tasks.TaskUnspecified, ErrInvalidTaskType
 }
 
 func (*Server) FeedTask(ctx context.Context, in *pb.FeedTaskRequest) (*pb.FeedTaskResponse, error) {

--- a/rpc/internal/server/procs.go
+++ b/rpc/internal/server/procs.go
@@ -33,9 +33,9 @@ func (s *Server) CreateFeed(ctx context.Context, in *pb.CreateFeedRequest) (*pb.
 	copygen.ProtoCreateFeedToService(feed, in.GetFeed())
 	res, err := s.service.CreateFeed(ctx, feed)
 	if err != nil {
-		if err == service.ErrDuplicate {
+		if errors.Is(err, service.ErrDuplicate) {
 			return nil, status.Errorf(codes.AlreadyExists, "feed already exists")
-		} else if err == service.ErrValidation {
+		} else if errors.Is(err, service.ErrValidation) {
 			return nil, validationErr(res.ValidationErrors)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to create feed: %v", err)
@@ -117,7 +117,7 @@ func (s *Server) SaveArticle(ctx context.Context, in *pb.SaveArticleRequest) (*p
 
 	res, err := s.service.SaveArticle(ctx, article)
 	if err != nil {
-		if err == service.ErrValidation {
+		if errors.Is(err, service.ErrValidation) {
 			return nil, validationErr(res.ValidationErrors)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to save article: %v", err)

--- a/rpc/internal/tasks/tasks.go
+++ b/rpc/internal/tasks/tasks.go
@@ -51,10 +51,8 @@ func New(ctx context.Context, task TaskType) (*TaskResult, error) {
 }
 
 func taskTypeToWorkflow(taskType TaskType) (any, error) {
-	switch taskType {
-	case TaskGenerateFeeds:
+	if taskType == TaskGenerateFeeds {
 		return feed_tasks.GenerateFeedsWorkflow, nil
-	default:
-		return nil, errors.New("unknown task type")
 	}
+	return nil, errors.New("unknown task type")
 }

--- a/rpc/internal/tasks/tasks.go
+++ b/rpc/internal/tasks/tasks.go
@@ -11,6 +11,8 @@ import (
 	"go.temporal.io/sdk/temporal"
 )
 
+var ErrInvalidTaskType = errors.New("invalid task type")
+
 type TaskType string
 
 const (
@@ -54,5 +56,5 @@ func taskTypeToWorkflow(taskType TaskType) (any, error) {
 	if taskType == TaskGenerateFeeds {
 		return feed_tasks.GenerateFeedsWorkflow, nil
 	}
-	return nil, errors.New("unknown task type")
+	return nil, ErrInvalidTaskType
 }

--- a/rpc/pkg/client/client.go
+++ b/rpc/pkg/client/client.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+const Timeout = 10 * time.Second
+
 func New(target string, useInsecure bool) (pb.FeedServiceClient, Closer, error) {
 	// TODO: Option pattern
 
@@ -57,7 +59,7 @@ func defaultDialOpts() []grpc.DialOption {
 	return []grpc.DialOption{
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		grpc.WithChainUnaryInterceptor(
-			timeout.UnaryClientInterceptor(10*time.Second),
+			timeout.UnaryClientInterceptor(Timeout),
 			logging.UnaryClientInterceptor(logger, logOpts...),
 		),
 		grpc.WithChainStreamInterceptor(

--- a/services/echo/main.go
+++ b/services/echo/main.go
@@ -32,10 +32,10 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Error processing request", http.StatusInternalServerError)
 		return
 	}
-	lo.Must(fmt.Printf("headers: %+v\n", r.Header))
-	lo.Must(fmt.Printf("payload: %s\n", string(data)))
 
 	w.WriteHeader(http.StatusOK)
+	lo.Must(fmt.Fprintf(w, "headers: %+v\n", r.Header))
+	lo.Must(fmt.Fprintf(w, "payload: %s\n", string(data)))
 	if _, err := fmt.Fprintln(w, "Alert received"); err != nil {
 		slog.Error("Failed to write response", "error", err)
 	}

--- a/tools/graphql-schema/main.go
+++ b/tools/graphql-schema/main.go
@@ -19,9 +19,13 @@ const (
 // Downloads the GraphQL schema from the locally running server.
 // more info: https://github.com/Khan/genqlient/blob/main/docs/schema.md#fetching-your-schema
 func main() {
-	slog.Info("generating golang graphql schema", "serviceURL", serviceURL)
+	url := os.Getenv("GRAPH_HOST")
+	if url == "" {
+		url = serviceURL
+	}
+	slog.Info("generating golang graphql schema", "serviceURL", url)
 
-	schema, err := gqlfetch.BuildClientSchema(context.Background(), serviceURL, false)
+	schema, err := gqlfetch.BuildClientSchema(context.Background(), url, false)
 	if err != nil {
 		slog.Error("unable to query graph service", "error", err)
 		os.Exit(1)

--- a/ui/codegen.ts
+++ b/ui/codegen.ts
@@ -1,9 +1,11 @@
 
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
+const schemaURL = process.env.GRAPH_HOST || 'http://localhost:8082/query';
+
 const config: CodegenConfig = {
   overwrite: true,
-  schema: "http://localhost:8082/query",
+  schema: schemaURL,
   documents: [
     "app/graphql/queries.graphql",
     "app/graphql/mutations.graphql",


### PR DESCRIPTION
- fix bug with mismatched golangci-lint versions between local & remote
- add a few lint exclusions 
- document graph workflow; this really needs to be automated
- add env support to generators