### PR TITLE
fix: logging, helm, tilt overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __debug_bin*
 *.db
 .env
 reports/*
+Tiltfile.overrides

--- a/Tiltfile
+++ b/Tiltfile
@@ -4,6 +4,9 @@ load('ext://secret', 'secret_create_generic', 'secret_from_dict')
 load('ext://uibutton', 'cmd_button')
 secret_settings(disable_scrub=True)
 
+if os.path.exists("./Tiltfile.overrides"):
+  include("./Tiltfile.overrides")
+
 IS_CI = config.tilt_subcommand == 'ci'
 
 dotenv('.env.local')

--- a/containers/tilt/extensions/minio/Tiltfile
+++ b/containers/tilt/extensions/minio/Tiltfile
@@ -50,8 +50,9 @@ def deploy_minio(
     # Running cmd: helm repo add bitnami https://charts.bitnami.com/bitnami --force-update
     # Release "minio" does not exist. Installing it now.
     # Error: repo bitnami not found
-    local('helm repo add bitnami https://charts.bitnami.com/bitnami --force-update')
-    local('helm repo update')
+    if config.tilt_subcommand != 'down':
+        local('helm repo add bitnami https://charts.bitnami.com/bitnami --force-update')
+        local('helm repo update')
 
     helm_repo(helm_repo_name, helm_repo_url)
     helm_resource(

--- a/services/rpc/internal/server/grpc/grpc.go
+++ b/services/rpc/internal/server/grpc/grpc.go
@@ -78,6 +78,15 @@ func newLogger() (logging.Logger, []logging.Option) {
 // This code is simple enough to be copied and not imported.
 func interceptorLogger(l *slog.Logger) logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
+		// well this is ridiculous. ignore health check logs.
+		for i := 0; i < len(fields); i += 2 {
+			if key, ok := fields[i].(string); ok && key == "grpc.service" {
+				if val, ok := fields[i+1].(string); ok && val == "grpc.health.v1.Health" {
+					return
+				}
+				break
+			}
+		}
 		l.Log(ctx, slog.Level(lvl), msg, fields...)
 	})
 }


### PR DESCRIPTION
## Summary

- tilt overrides allows defining a custom Tiltfile.include (I am using this to set a custom registry and allow orbstack context)
- grpc logging interceptor ignore health check
- prevent install of helm chart on tilt down

## Checklist

_Before submitting, ensure the following:_

- [x] Tests have been written and/or updated.
- [x] All tests pass locally.
- [x] Linter passes with no errors or warnings.
- [x] Changes are documented in the README or other relevant documentation.

## How to Test

- tilt up should work without issue
- view rpc logs in tilt (no health check)
- tilt down should work quicker (no running helm)
