### PR TITLE
fix: feed fetch queue name & bucket creation

### DIFF
--- a/containers/tilt/extensions/minio/Tiltfile
+++ b/containers/tilt/extensions/minio/Tiltfile
@@ -15,37 +15,3 @@ def deploy_minio(
         auto_init=auto_init,
         labels=["services"],
     )
-
-    # k8s_resource(
-    #     "minio",
-    #     port_forwards=[
-    #         port_forward(9100, 9000, "minio-service"),
-    #         port_forward(9101, 9001, "minio-admin"),
-    #     ]
-    # if not labels:
-    #     labels = ["data-pipeline"]
-    # k8s_yaml(
-    #     secret_from_dict(
-    #         secret_name,
-    #         inputs={
-    #             "root-user": root_user,
-    #             "root-password": root_password,
-    #         },
-    #     )
-    # )
-    # # TODO: revisit- i was getting an error saying repo doesn't exist:
-    # # Running cmd: helm repo add bitnami https://charts.bitnami.com/bitnami --force-update
-    # # Release "minio" does not exist. Installing it now.
-    # # Error: repo bitnami not found
-    # if config.tilt_subcommand != 'down':
-    #     local('helm repo add bitnami https://charts.bitnami.com/bitnami --force-update')
-    #     local('helm repo update')
-    # helm_repo(helm_repo_name, helm_repo_url)
-    # helm_resource(
-    #     name="minio",
-    #     chart=chart_name,
-    #     flags=chart_flags,
-    #     port_forwards=port_mappings,
-    #     auto_init=auto_init,
-    #     labels=labels,
-    # )

--- a/data-pipeline/temporal/feed_fetch/activity.go
+++ b/data-pipeline/temporal/feed_fetch/activity.go
@@ -82,6 +82,10 @@ func (a *Activities) DownloadActivity(ctx context.Context, feedId string, url st
 			return ErrContentNotChanged
 		}
 
+		if err := a.bucket.Create(ctx, BucketName); err != nil {
+			return err
+		}
+
 		upload, err := a.bucket.WriteStream(ctx, BucketName, rssFile, params.Reader, params.ContentType)
 		if err != nil {
 			return err

--- a/data-pipeline/temporal/feed_fetch/activity_test.go
+++ b/data-pipeline/temporal/feed_fetch/activity_test.go
@@ -62,7 +62,9 @@ func TestDownloadActivity(t *testing.T) {
 	s.fetcher.EXPECT().
 		Url(mock.Anything, url, matcher, mock.Anything). // TODO: use etag
 		Return(nil)
-
+	s.bucket.EXPECT().
+		Create(mock.Anything, app.BucketName).
+		Return(nil)
 	s.bucket.EXPECT().
 		WriteStream(mock.Anything, app.BucketName, rssFile, reader, contentType).
 		Return(&bucket.UploadInfo{Key: rssFile, Bucket: app.BucketName}, nil)

--- a/data-pipeline/temporal/feed_tasks/activity.go
+++ b/data-pipeline/temporal/feed_tasks/activity.go
@@ -51,7 +51,7 @@ func (a *Activities) RefreshFeeds(ctx context.Context) error {
 	config := lo.Must(env.New[Config]())
 
 	opts := sdk.StartWorkflowOptions{
-		TaskQueue: config.TaskQueue,
+		TaskQueue: config.FeedFetchQueue,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 1,
 		},


### PR DESCRIPTION
Fixed the following errors:

feed fetch worker

```
{"time":"2025-09-20T11:28:38.536859243Z","level":"ERROR","msg":"Activity error.","Namespace":"default","TaskQueue":"feed-fetch-queue","WorkerID":"63@feed-fetch-worker-569cb549c9-mj7r4@","WorkflowID":"019966e2-1c4e-756d-a629-6539080bd0ce_12","RunID":"019966e2-1c67-75dd-8cae-4ac2cea3f598","ActivityType":"DownloadActivity","Attempt":1,"Error":"failed to put object: The specified bucket does not exist"}
```

feed tasks worker:

```
{"time":"2025-09-20T11:29:29.521056356Z","level":"WARN","msg":"Failed to process workflow task.","Namespace":"default","TaskQueue":"feed-tasks-queue","WorkerID":"61@feed-tasks-worker-676df55b4c-4hns9@","WorkflowType":"FetchFeedsWorkflow","WorkflowID":"3e1a9698-d271-447d-8928-8ac0db021746","RunID":"019966dd-4942-7851-9b27-175e52a86810","Attempt":10,"Error":"unable to find workflow type: FetchFeedsWorkflow. Supported types: [GenerateFeedsWorkflow, RefreshFeedsWorkflow]"}
```